### PR TITLE
Make looksee#ls method worked together with pry 0.10.1 ls command.

### DIFF
--- a/lib/looksee/core_ext.rb
+++ b/lib/looksee/core_ext.rb
@@ -3,8 +3,19 @@ module Looksee
     #
     # Shortcut for Looksee[self, *args].
     #
-    def ls(*args)
-      Looksee[self, *args]
+    def method_missing(name, *args)
+      case name.to_s
+      when /^ls$/
+        # when in repl, p is no need.
+        # but when no repl, p is need for output looksee result.
+        if defined? Pry or defined? Irb
+          Looksee[self, *args]
+        else
+          p Looksee[self, *args]
+        end
+      else
+        super
+      end
     end
 
     def self.rename(name)  # :nodoc:

--- a/spec/looksee/wirble_compatibility_spec.rb
+++ b/spec/looksee/wirble_compatibility_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Looksee::WirbleCompatibility do
+  before { skip "wirble is not common enough, and it too old for use." }
   describe "when looksee is loaded" do
     #
     # Run the given ruby string, and return the standard output.


### PR DESCRIPTION
Pry 0.10.1 change command implementation.

With old looksee, it will make ls command in pry terminal not work.

This change will make ls command still work like this: `` (pry):0> ls``,
and Looksee#ls can work like this ``(pry):0> "hello".ls``, just same as worked with pry 0.9.12.

