### PR TITLE
Looksee.rename is broken

### DIFF
--- a/lib/looksee/core_ext.rb
+++ b/lib/looksee/core_ext.rb
@@ -7,7 +7,7 @@ module Looksee
     # relies on Object#ls not existing.
     #
     def method_missing(name, *args)
-      if name == :ls
+      if name == Looksee::ObjectMixin.looksee_method
         Looksee[self, *args]
       else
         super
@@ -15,13 +15,16 @@ module Looksee
     end
 
     def respond_to?(name, include_private=false)
-      super || name == :ls
+      super || name == Looksee::ObjectMixin.looksee_method
+    end
+
+    def self.looksee_method
+      @looksee_method ||= :ls
     end
 
     def self.rename(name)  # :nodoc:
       name = name[:ls] if name.is_a?(Hash)
-      alias_method name, :ls
-      remove_method :ls
+      Looksee::ObjectMixin.instance_variable_set :@looksee_method, name
     end
   end
 

--- a/spec/looksee/core_ext_spec.rb
+++ b/spec/looksee/core_ext_spec.rb
@@ -1,17 +1,28 @@
 require 'spec_helper'
 
 describe Looksee::ObjectMixin do
-  describe "#ls" do
-    before do
-      @object = Object.new
-      Looksee.stub(:default_specifiers).and_return([])
-    end
+  before do
+    @object = Object.new
+    Looksee.stub(:default_specifiers).and_return([])
+  end
 
+  describe "#ls" do
     it "should return an Inspector for the object's lookup path using the given arguments" do
       result = @object.ls(:private)
       result.should be_a(Looksee::Inspector)
       result.lookup_path.object.should.equal?(@object)
       result.visibilities.should == Set[:private]
+    end
+  end
+
+  describe '.rename' do
+    it 'renames the name of the mixin' do
+      Looksee::ObjectMixin.rename(:lp)
+      @object.should_not respond_to(:ls)
+      expect{ @object.ls }.to raise_error(NoMethodError)
+      @object.should respond_to(:lp)
+      result = @object.lp
+      result.should be_a(Looksee::Inspector)
     end
   end
 end


### PR DESCRIPTION
First of all, thank you for this great debugging tool!

I've noticed that renaming the object mixin is broken with version 3.0. This is a suggestion to fix it.