### PR TITLE
Add troubleshooting section to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -142,6 +142,21 @@ We've got one:
 
 Enjoy!
 
+## Troubleshooting
+
+### ASCII Color Codes
+My output is not pretty, it's full of escape characters and looks something like this:
+
+    ESC[1;37mModuleESC[0m
+    ESC[1;32m<ESC[0m                ESC[1;32mancestorsESC[0m                ESC[1;32mattr_internal_readerESC[0m       ESC[1;32mcattr_writerESC[0m             ESC[1;32mconst_setESC[0m            ESC[1;32mfreezeESC[0m            ESC[1;32minstance_methodESC[0m   ESC[1;32mmethod_visibilityESC[0m  ESC[1;31mprepend_featuresESC[0m          ESC[1;31mprotectedESC[0m                   ESC[1;32mpublic_method_defined?ESC[0m     ESC[1;32mremove_possible_methodESC[0m       ESC[1;32mthread_mattr_writerESC[0m
+    ESC[1;32m<=ESC[0m
+
+These are color codes for the display, but when you have long output, your console uses a pager which isn't displaying them properly. You can verify this is the problem by checking ```[].ls(:public)``` assuming that fits on one page, your console won't use a pager and it should look normal. 
+
+If less is your pager, then the solution is to add the -R option. I add this to my ```.zshrc```
+
+    export LESS='-R'
+
 ## Contributing
 
  * [Bug reports](https://github.com/oggy/looksee/issues)


### PR DESCRIPTION
I tripped over #6  today. I found the solution in the issues section, but I'm suggesting bringing the solution to the readme to make it easier for people to find the next time. (also, the solution is on a 3rd party site, hopefully it will be there forever, but ...)