### PR TITLE
Ruby2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ rvm:
   - 2.1.9
   - 2.2.9
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
   - jruby-9.0.5.0
   - jruby-9.1.2.0
 matrix:
@@ -16,4 +17,5 @@ matrix:
     # rbx no longer builds on travis
     - rvm: rbx-2.4.1
     - rvm: rbx-2.5.8
+    - rvm: 2.2.10
   fast_finish: true

--- a/ext/mri/2.3.0/internal.h
+++ b/ext/mri/2.3.0/internal.h
@@ -1360,7 +1360,7 @@ void rb_gc_mark_global_tbl(void);
 void rb_mark_generic_ivar(VALUE);
 VALUE rb_const_missing(VALUE klass, VALUE name);
 int rb_class_ivar_set(VALUE klass, ID vid, VALUE value);
-st_table *rb_st_copy(VALUE obj, struct st_table *orig_tbl);
+// st_table *rb_st_copy(VALUE obj, struct st_table *orig_tbl);
 
 /* gc.c (export) */
 VALUE rb_wb_protected_newobj_of(VALUE, VALUE);

--- a/lib/looksee/version.rb
+++ b/lib/looksee/version.rb
@@ -1,5 +1,5 @@
 module Looksee
-  VERSION = [4, 1, 0]
+  VERSION = [4, 1, 1]
 
   class << VERSION
     include Comparable


### PR DESCRIPTION
You will find this fix quite boring
but the breaking line, which was refactored in https://github.com/ruby/ruby/commit/5f35b8ca30cba69968d4d0c885a4bf5c48b03e17 isn't used by looksee and can be simply commented out

looksee installs and works fine in 2.7 with this small change

note the `internal.h` was split in several files in ruby. but I don't know if we need to care so much...
https://github.com/ruby/ruby/commit/5e22f873ed26092522f9bfc617d729bac88b284f

